### PR TITLE
update how user info is serialzied,

### DIFF
--- a/src/routes/auth.ts
+++ b/src/routes/auth.ts
@@ -19,10 +19,13 @@ passport.use(
             callbackURL,
         },
         (accessToken, _refreshToken, _expires_in, profile, done) => {
+            // profile image returns as an object, but typescript declares it as a [string], so we cant access value without the below code.
+            const profileImageArr = <[{ value: string }]>(<unknown>profile.photos);
+            const profileImage = profileImageArr[0].value;
             const user = {
                 accessToken,
                 displayName: profile.displayName,
-                profileImage: profile.photos,
+                profileImage,
                 product: profile.product,
                 id: profile.id,
             };
@@ -57,15 +60,6 @@ router.get(
     '/callback',
     passport.authenticate('spotify', { failureRedirect: '/error' }),
     (req: RequestWithUser, res: Response) => {
-        // profile image returns as an object, but typescript declares it as a string, so we cant access value without the below code.
-        // This code does nothign right now, come back and refactor when possible. :)
-        if (typeof req.user.profileImage[0] === 'object') {
-            const profileImage: { value: string } = <{ value: string }>req.user.profileImage[0];
-            req.user = { ...req.user, profileImage: profileImage.value };
-        } else if (typeof req.user.profileImage[0] === ('undefined' || 'null')) {
-            req.user = { ...req.user, profileImage: null };
-        }
-
         res.redirect(process.env.FRONTEND_URL);
     },
 );


### PR DESCRIPTION
 User will now have a key/value pair of ``profileImage: 'img url'``

I was overcomplicating the process of checking for an object, some rest cleared the fog. 🌫👓  
A simple 'type assertation' works here as long as you convert it to unknown first.

```typescript

 const profileImageArr = <[{ value: string }]>(<unknown>profile.photos);
 const profileImage = profileImageArr[0].value;
// eg
const img = <NewTypeAssert><unknown>ValueToBeAsserted
```